### PR TITLE
Improved error messaging when the image pull fails.

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -51,7 +51,9 @@
       "WebFetch(domain:support.claude.com)",
       "WebFetch(domain:docs.z.ai)",
       "WebFetch(domain:cursor.com)",
-      "WebFetch(domain:ampcode.com)"
+      "WebFetch(domain:ampcode.com)",
+      "Bash(go build:*)",
+      "Bash(go test:*)"
     ],
     "deny": [],
     "ask": []

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,12 +22,12 @@ var (
 	runRuntime    string
 	runConfig     string
 	// Credential flags
-	runGitCreds   *bool
-	runSSHCreds   *bool
-	runGHCreds    *bool
-	runGPGCreds   *bool
-	runNPMCreds   *bool
-	runAllCreds   bool
+	runGitCreds *bool
+	runSSHCreds *bool
+	runGHCreds  *bool
+	runGPGCreds *bool
+	runNPMCreds *bool
+	runAllCreds bool
 )
 
 var runCmd = &cobra.Command{
@@ -53,8 +53,9 @@ var runCmd = &cobra.Command{
 				// Config doesn't exist - use defaults
 				cfg = &config.Config{
 					ContainerRuntime: runRuntime,
+					DefaultImage:     "ghcr.io/obra/packnplay-default:latest",
 					DefaultCredentials: config.Credentials{
-						Git: true, // Always copy .gitconfig
+						Git: true,  // Always copy .gitconfig
 						SSH: false, // SSH keys are credentials - user choice
 						GH:  false, // GitHub auth - user choice
 					},
@@ -118,6 +119,7 @@ var runCmd = &cobra.Command{
 			Env:            append(runEnv, configEnv...), // Merge user env vars with config env vars
 			Verbose:        runVerbose,
 			Runtime:        runtime,
+			DefaultImage:   cfg.DefaultImage,
 			Command:        args,
 			Credentials:    creds,
 			DefaultEnvVars: cfg.DefaultEnvVars,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,10 +12,11 @@ import (
 
 // Config represents packnplay's configuration
 type Config struct {
-	ContainerRuntime   string                 `json:"container_runtime"`   // docker, podman, or container
-	DefaultCredentials Credentials            `json:"default_credentials"`
-	DefaultEnvVars     []string               `json:"default_env_vars"`    // API keys to always proxy
-	EnvConfigs         map[string]EnvConfig   `json:"env_configs"`
+	ContainerRuntime   string               `json:"container_runtime"` // docker, podman, or container
+	DefaultImage       string               `json:"default_image"`     // default container image to use
+	DefaultCredentials Credentials          `json:"default_credentials"`
+	DefaultEnvVars     []string             `json:"default_env_vars"` // API keys to always proxy
+	EnvConfigs         map[string]EnvConfig `json:"env_configs"`
 }
 
 // EnvConfig defines environment variables for different setups (API configs, etc.)
@@ -70,6 +71,11 @@ func Load() (*Config, error) {
 		return interactiveSetup(configPath)
 	}
 
+	// Set default image if not configured (backward compatibility)
+	if cfg.DefaultImage == "" {
+		cfg.DefaultImage = "ghcr.io/obra/packnplay-default:latest"
+	}
+
 	return &cfg, nil
 }
 
@@ -91,6 +97,11 @@ func LoadWithoutRuntimeCheck() (*Config, error) {
 	var cfg Config
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	// Set default image if not configured (backward compatibility)
+	if cfg.DefaultImage == "" {
+		cfg.DefaultImage = "ghcr.io/obra/packnplay-default:latest"
 	}
 
 	return &cfg, nil
@@ -197,6 +208,7 @@ func interactiveSetup(configPath string) (*Config, error) {
 
 	cfg := &Config{
 		ContainerRuntime: selectedRuntime,
+		DefaultImage:     "ghcr.io/obra/packnplay-default:latest",
 		DefaultCredentials: Credentials{
 			Git: true, // Always copy .gitconfig (it's config, not credentials)
 			SSH: sshCreds,
@@ -246,4 +258,3 @@ func detectAvailableRuntimes() []string {
 
 	return available
 }
-

--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -41,9 +41,13 @@ func LoadConfig(projectPath string) (*Config, error) {
 }
 
 // GetDefaultConfig returns the default devcontainer config
-func GetDefaultConfig() *Config {
+// If defaultImage is empty, uses "ghcr.io/obra/packnplay-default:latest"
+func GetDefaultConfig(defaultImage string) *Config {
+	if defaultImage == "" {
+		defaultImage = "ghcr.io/obra/packnplay-default:latest"
+	}
 	return &Config{
-		Image:      "ghcr.io/obra/packnplay-default:latest",
+		Image:      defaultImage,
 		RemoteUser: "vscode",
 	}
 }

--- a/pkg/devcontainer/config_test.go
+++ b/pkg/devcontainer/config_test.go
@@ -49,3 +49,24 @@ func TestLoadConfig_NotFound(t *testing.T) {
 		t.Errorf("LoadConfig() = %v, want nil for missing config", config)
 	}
 }
+
+func TestGetDefaultConfig(t *testing.T) {
+	// Test with empty string - should use default
+	config := GetDefaultConfig("")
+	if config.Image != "ghcr.io/obra/packnplay-default:latest" {
+		t.Errorf("GetDefaultConfig(\"\") Image = %v, want ghcr.io/obra/packnplay-default:latest", config.Image)
+	}
+	if config.RemoteUser != "vscode" {
+		t.Errorf("GetDefaultConfig(\"\") RemoteUser = %v, want vscode", config.RemoteUser)
+	}
+
+	// Test with custom image
+	customImage := "mycustom/image:v1"
+	config = GetDefaultConfig(customImage)
+	if config.Image != customImage {
+		t.Errorf("GetDefaultConfig(%v) Image = %v, want %v", customImage, config.Image, customImage)
+	}
+	if config.RemoteUser != "vscode" {
+		t.Errorf("GetDefaultConfig(%v) RemoteUser = %v, want vscode", customImage, config.RemoteUser)
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -23,6 +23,7 @@ type RunConfig struct {
 	Env            []string
 	Verbose        bool
 	Runtime        string // docker, podman, or container
+	DefaultImage   string // default container image to use
 	Command        []string
 	Credentials    config.Credentials
 	DefaultEnvVars []string // API keys to proxy from host
@@ -121,7 +122,7 @@ func Run(config *RunConfig) error {
 		return fmt.Errorf("failed to load devcontainer config: %w", err)
 	}
 	if devConfig == nil {
-		devConfig = devcontainer.GetDefaultConfig()
+		devConfig = devcontainer.GetDefaultConfig(config.DefaultImage)
 	}
 
 	// Step 4: Initialize container client


### PR DESCRIPTION
Provides a more detailed error message when the image pull fails. For example:

```
failed to pull image ghcr.io/obra/packnplay-default:latest: exit status 1
Docker output:
Error response from daemon: error from registry: unauthorized
unauthorized
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a configurable default container image with a sensible fallback (ghcr.io/obra/packnplay-default:latest) when none is set.
* **Bug Fixes**
  * Enhanced Docker-related error messages now include command output for clearer diagnostics.
* **Chores**
  * Expanded local allowed commands to include Go build and test.
* **Tests**
  * Added unit tests validating default container image behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->