### PR TITLE
feat: support XDG git config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Override default credential settings per-invocation:
 
 ```bash
 # Enable specific credentials
-packnplay run --git-creds claude           # Mount git config (~/.gitconfig)
+packnplay run --git-creds claude           # Mount git config (~/.gitconfig, ~/.config/git/config)
 packnplay run --ssh-creds claude           # Mount SSH keys (~/.ssh)
 packnplay run --gh-creds claude            # Mount GitHub CLI credentials
 packnplay run --gpg-creds claude           # Mount GPG keys for signing
@@ -362,7 +362,7 @@ See [.devcontainer/README.md](.devcontainer/README.md) for instructions on build
 On first run, packnplay prompts you to choose which credentials to enable by default using a beautiful terminal UI.
 
 **Credentials are mounted read-only for security:**
-- **Git**: `~/.gitconfig` (git user configuration)
+- **Git**: `~/.gitconfig`, `~/.config/git/config` (git user configuration)
 - **SSH**: `~/.ssh` (SSH keys for authentication to servers and repos)
 - **GitHub CLI**: `~/.config/gh` (copied from Keychain on macOS, mounted on Linux)
 - **GPG**: `~/.gnupg` (for commit signing)

--- a/pkg/runner/mount_builder.go
+++ b/pkg/runner/mount_builder.go
@@ -92,6 +92,16 @@ func (mb *MountBuilder) buildCredentialMounts(creds config.Credentials) []string
 			target := fmt.Sprintf("/home/%s/.gitconfig", mb.containerUser)
 			args = append(args, "-v", fmt.Sprintf("%s:%s:ro", gitconfig, target))
 		}
+		// Also check XDG location
+		xdgGitconfig := filepath.Join(mb.hostHomeDir, ".config", "git", "config")
+		if fileExists(xdgGitconfig) {
+			resolvedPath, err := resolveMountPath(xdgGitconfig)
+			if err != nil {
+				resolvedPath = xdgGitconfig
+			}
+			target := fmt.Sprintf("/home/%s/.config/git/config", mb.containerUser)
+			args = append(args, "-v", fmt.Sprintf("%s:%s:ro", resolvedPath, target))
+		}
 	}
 
 	if creds.SSH {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -828,6 +828,18 @@ func Run(config *RunConfig) error {
 			}
 			args = append(args, "-v", fmt.Sprintf("%s:/home/%s/.gitconfig:ro", resolvedPath, devConfig.RemoteUser))
 		}
+		// Also check XDG location
+		xdgGitconfigPath := filepath.Join(homeDir, ".config", "git", "config")
+		if fileExists(xdgGitconfigPath) {
+			resolvedPath, err := resolveMountPath(xdgGitconfigPath)
+			if err != nil {
+				if config.Verbose {
+					fmt.Fprintf(os.Stderr, "Warning: failed to resolve .config/git/config symlink: %v\n", err)
+				}
+				resolvedPath = xdgGitconfigPath
+			}
+			args = append(args, "-v", fmt.Sprintf("%s:/home/%s/.config/git/config:ro", resolvedPath, devConfig.RemoteUser))
+		}
 	}
 
 	// Mount SSH keys


### PR DESCRIPTION
Mount ~/.config/git/config in addition to ~/.gitconfig when git credentials mounting is enabled.

## Motivation and Context
Git supports the XDG Base Directory specification, looking for config at ~/.config/git/config in addition to the traditional ~/.gitconfig. Users who organize their dotfiles following XDG conventions have their git config at the XDG location, which wasn't being mounted into containers.

## How Has This Been Tested?
- Verified code compiles
- Ran existing mount-related tests (go test ./pkg/runner/... -run "Mount")
- Logic mirrors existing ~/.gitconfig handling, including symlink resolution
- Verified that built binary properly mounts XDG git config location

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Git integration: when Git credentials are enabled, the XDG Git config (~/.config/git/config) is now also mounted read-only alongside the existing ~/.gitconfig when present. The XDG config is mounted only if it exists; no changes occur if it’s absent.

* **Documentation**
  * README updated to show both ~/.gitconfig and the XDG Git config are supported and included in examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->