### PR TITLE
test: finish short mode support and consolidate Docker skip guards

### DIFF
--- a/pkg/userdetect/detect_test.go
+++ b/pkg/userdetect/detect_test.go
@@ -7,10 +7,21 @@ import (
 	"testing"
 )
 
-func TestDetectContainerUser(t *testing.T) {
+// skipIfNoDocker skips the test if running in short mode or Docker is unavailable
+func skipIfNoDocker(t *testing.T) {
+	t.Helper()
+
 	if testing.Short() {
-		t.Skip("skipping Docker-dependent test in short mode")
+		t.Skip("Skipping Docker-dependent test in short mode")
 	}
+
+	if !isDockerAvailable() {
+		t.Skip("Skipping test: Docker not available")
+	}
+}
+
+func TestDetectContainerUser(t *testing.T) {
+	skipIfNoDocker(t)
 
 	tests := []struct {
 		name         string
@@ -53,11 +64,6 @@ func TestDetectContainerUser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Skip tests that require Docker if not available
-			if !isDockerAvailable() {
-				t.Skip("Docker not available")
-			}
-
 			result, err := DetectContainerUser(tt.image, tt.devcontainer)
 
 			if tt.shouldError {
@@ -88,9 +94,7 @@ func TestDetectContainerUser(t *testing.T) {
 }
 
 func TestDetectUsersInImage(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping Docker-dependent test in short mode")
-	}
+	skipIfNoDocker(t)
 
 	tests := []struct {
 		name          string
@@ -111,10 +115,6 @@ func TestDetectUsersInImage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if !isDockerAvailable() {
-				t.Skip("Docker not available")
-			}
-
 			users, err := DetectUsersInImage(tt.image)
 			if err != nil {
 				t.Fatalf("DetectUsersInImage() error = %v", err)
@@ -138,9 +138,7 @@ func TestDetectUsersInImage(t *testing.T) {
 }
 
 func TestGetImageDefaultUser(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping Docker-dependent test in short mode")
-	}
+	skipIfNoDocker(t)
 
 	tests := []struct {
 		name         string
@@ -161,10 +159,6 @@ func TestGetImageDefaultUser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if !isDockerAvailable() {
-				t.Skip("Docker not available")
-			}
-
 			user, err := GetImageDefaultUser(tt.image)
 			if err != nil {
 				t.Fatalf("GetImageDefaultUser() error = %v", err)
@@ -178,12 +172,7 @@ func TestGetImageDefaultUser(t *testing.T) {
 }
 
 func TestDirectDetection(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping Docker-dependent test in short mode")
-	}
-	if !isDockerAvailable() {
-		t.Skip("Docker not available")
-	}
+	skipIfNoDocker(t)
 
 	// Test direct detection with a simple image
 	result, err := detectRuntimeUserDirect("ubuntu:22.04")
@@ -207,12 +196,7 @@ func TestDirectDetection(t *testing.T) {
 }
 
 func TestCaching(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping Docker-dependent test in short mode")
-	}
-	if !isDockerAvailable() {
-		t.Skip("Docker not available")
-	}
+	skipIfNoDocker(t)
 
 	image := "ubuntu:22.04"
 
@@ -256,12 +240,7 @@ func TestCaching(t *testing.T) {
 }
 
 func TestGetImageID(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping Docker-dependent test in short mode")
-	}
-	if !isDockerAvailable() {
-		t.Skip("Docker not available")
-	}
+	skipIfNoDocker(t)
 
 	imageID, err := getImageID("ubuntu:22.04")
 	if err != nil {


### PR DESCRIPTION
Finished short mode support. Consolidated Docker skip guards.

## Motivation and Context

Some short mode tests (i.e., unit tests) in `pkg/userdetect/detect_test.go` depended on Docker, but `docs/` indicates such tests should not be included in short mode (i.e., are e2e tests).

While at it, consolidated Docker skip guards into a reusable helper function and added short mode skipping for faster test runs.

## How Has This Been Tested?

Locally: `go test --short ./...`

## Breaking Changes

None. Internal refactor of test code.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

I came across this while hacking on a feature idea.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test organization by consolidating Docker availability checks into a centralized helper function, reducing code duplication across test cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->