### PR TITLE
feature: support Claude Code plugins via dual mount for ~/.claude path resolution

### DIFF
--- a/docs/plans/2026-01-02-claude-plugin-path-fix-design.md
+++ b/docs/plans/2026-01-02-claude-plugin-path-fix-design.md
@@ -105,19 +105,37 @@ func TestClaudeAgentDualMount(t *testing.T) {
     agent := &ClaudeAgent{}
 
     // macOS-style: different paths -> dual mount
-    mounts := agent.GetMounts("/Users/testuser", "vscode")
-    assert.Len(t, mounts, 2)
-    assert.Equal(t, "/Users/testuser/.claude", mounts[0].ContainerPath)
-    assert.Equal(t, "/home/vscode/.claude", mounts[1].ContainerPath)
+    t.Run("different paths produces dual mount", func(t *testing.T) {
+        mounts := agent.GetMounts("/Users/testuser", "vscode")
+        if len(mounts) != 2 {
+            t.Fatalf("GetMounts() returned %d mounts, want 2", len(mounts))
+        }
+        if mounts[0].ContainerPath != "/Users/testuser/.claude" {
+            t.Errorf("Mount[0] ContainerPath = %v, want /Users/testuser/.claude", mounts[0].ContainerPath)
+        }
+        if mounts[1].ContainerPath != "/home/vscode/.claude" {
+            t.Errorf("Mount[1] ContainerPath = %v, want /home/vscode/.claude", mounts[1].ContainerPath)
+        }
+    })
 
     // Linux same-user: identical paths -> single mount
-    mounts = agent.GetMounts("/home/vscode", "vscode")
-    assert.Len(t, mounts, 1)
+    t.Run("identical paths produces single mount", func(t *testing.T) {
+        mounts := agent.GetMounts("/home/vscode", "vscode")
+        if len(mounts) != 1 {
+            t.Fatalf("GetMounts() returned %d mounts, want 1", len(mounts))
+        }
+    })
 
-    // Root user
-    mounts = agent.GetMounts("/Users/testuser", "root")
-    assert.Len(t, mounts, 2)
-    assert.Equal(t, "/root/.claude", mounts[1].ContainerPath)
+    // Root user with different host path -> dual mount
+    t.Run("root user produces dual mount", func(t *testing.T) {
+        mounts := agent.GetMounts("/Users/testuser", "root")
+        if len(mounts) != 2 {
+            t.Fatalf("GetMounts() returned %d mounts, want 2", len(mounts))
+        }
+        if mounts[1].ContainerPath != "/root/.claude" {
+            t.Errorf("Mount[1] ContainerPath = %v, want /root/.claude", mounts[1].ContainerPath)
+        }
+    })
 }
 ```
 
@@ -146,4 +164,5 @@ Verify `BuildAgentMounts()` produces correct Docker `-v` flags.
 
 1. `pkg/agents/agent.go` - Update `ClaudeAgent.GetMounts()`
 2. `pkg/agents/agent_test.go` - Add dual mount tests
-3. `pkg/runner/mount_builder_test.go` - Update integration tests if needed
+3. `pkg/runner/runner.go` - Remove redundant hardcoded `.claude` mount (now handled by agent abstraction)
+4. `pkg/runner/mount_builder_test.go` - Update integration tests if needed

--- a/docs/plans/2026-01-02-claude-plugin-path-fix-design.md
+++ b/docs/plans/2026-01-02-claude-plugin-path-fix-design.md
@@ -1,0 +1,149 @@
+# Claude Code Plugin Path Fix Design
+
+## Problem
+
+Claude Code plugins and skills don't work when running via `packnplay run claude` because `installed_plugins.json` contains hardcoded absolute host paths that don't exist inside the container.
+
+**Example:**
+```json
+{
+  "plugins": {
+    "superpowers@superpowers-marketplace": [{
+      "installPath": "/Users/myuser/.claude/plugins/cache/superpowers-marketplace/superpowers/4.0.3"
+    }]
+  }
+}
+```
+
+Currently, packnplay mounts `~/.claude` to a different path:
+- Host: `/Users/myuser/.claude`
+- Container: `/home/{remoteUser}/.claude`
+
+When Claude Code reads `installed_plugins.json`, it tries to access `/Users/myuser/.claude/plugins/cache/...` which doesn't exist in the container.
+
+## Solution: Dual Mount
+
+Mount `~/.claude` at **both** paths:
+1. Same as host path (for absolute path resolution in plugin files)
+2. At container `$HOME/.claude` (for Claude Code config discovery)
+
+Docker fully supports mounting the same source to multiple targets.
+
+## Implementation
+
+**File:** `pkg/agents/agent.go`
+
+**Change `ClaudeAgent.GetMounts()`:**
+
+```go
+func (c *ClaudeAgent) GetMounts(hostHomeDir string, containerUser string) []Mount {
+    containerHomeDir := "/root"
+    if containerUser != "root" {
+        containerHomeDir = "/home/" + containerUser
+    }
+
+    hostClaudePath := filepath.Join(hostHomeDir, ".claude")
+    containerClaudePath := filepath.Join(containerHomeDir, ".claude")
+
+    // If paths are already the same, only need one mount
+    if hostClaudePath == containerClaudePath {
+        return []Mount{
+            {
+                HostPath:      hostClaudePath,
+                ContainerPath: containerClaudePath,
+                ReadOnly:      false,
+            },
+        }
+    }
+
+    // Dual mount: same-path for absolute references + $HOME path for Claude discovery
+    return []Mount{
+        {
+            HostPath:      hostClaudePath,
+            ContainerPath: hostClaudePath,  // Same as host (for plugin absolute paths)
+            ReadOnly:      false,
+        },
+        {
+            HostPath:      hostClaudePath,
+            ContainerPath: containerClaudePath,  // At container $HOME (for Claude Code)
+            ReadOnly:      false,
+        },
+    }
+}
+```
+
+## Design Rationale
+
+### Why Dual Mount Over Alternatives?
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Dual mount** | Simple, no lifecycle commands, works immediately | Two mount entries |
+| Symlink at startup | Single mount | Requires postCreateCommand, adds complexity |
+| Path rewriting | Could fix all paths | High complexity, fragile |
+| CLAUDE_CONFIG_DIR | Simple env var | Doesn't fix paths inside installed_plugins.json |
+
+Dual mount aligns with packnplay's philosophy of minimal complexity and transparency.
+
+### Why Not Same-Path Only?
+
+Claude Code discovers its config at `$HOME/.claude`. If we only mount at the host path (e.g., `/Users/aedgcomb/.claude`), Claude Code wouldn't find its config unless we also set `HOME=/Users/aedgcomb`, which would break other container expectations.
+
+## Edge Cases
+
+1. **Identical paths** (Linux, same user): Optimization skips dual mount
+2. **Root container user**: Uses `/root/.claude` as second path
+3. **Credential overlay**: Still targets `$HOME/.claude` path correctly
+4. **Host path doesn't exist**: Docker creates directory automatically
+
+## Testing
+
+### Unit Tests (`pkg/agents/agent_test.go`)
+
+```go
+func TestClaudeAgentDualMount(t *testing.T) {
+    agent := &ClaudeAgent{}
+
+    // macOS-style: different paths -> dual mount
+    mounts := agent.GetMounts("/Users/testuser", "vscode")
+    assert.Len(t, mounts, 2)
+    assert.Equal(t, "/Users/testuser/.claude", mounts[0].ContainerPath)
+    assert.Equal(t, "/home/vscode/.claude", mounts[1].ContainerPath)
+
+    // Linux same-user: identical paths -> single mount
+    mounts = agent.GetMounts("/home/vscode", "vscode")
+    assert.Len(t, mounts, 1)
+
+    // Root user
+    mounts = agent.GetMounts("/Users/testuser", "root")
+    assert.Len(t, mounts, 2)
+    assert.Equal(t, "/root/.claude", mounts[1].ContainerPath)
+}
+```
+
+### Integration Tests (`pkg/runner/mount_builder_test.go`)
+
+Verify `BuildAgentMounts()` produces correct Docker `-v` flags.
+
+### Manual E2E Verification
+
+1. Install Claude Code plugins on host
+2. Run `packnplay run claude`
+3. Verify `/superpowers:brainstorming` works
+
+## Release Notes
+
+```markdown
+### Bug Fixes
+
+- **Claude Code Plugin Support**: Fixed plugin/skill discovery when running
+  via `packnplay run claude`. Plugins now work correctly by mounting
+  `~/.claude` at both the host path (for absolute path resolution) and
+  the container's `$HOME/.claude` (for Claude Code discovery).
+```
+
+## Files to Modify
+
+1. `pkg/agents/agent.go` - Update `ClaudeAgent.GetMounts()`
+2. `pkg/agents/agent_test.go` - Add dual mount tests
+3. `pkg/runner/mount_builder_test.go` - Update integration tests if needed

--- a/pkg/agents/agent.go
+++ b/pkg/agents/agent.go
@@ -49,11 +49,33 @@ func (c *ClaudeAgent) GetMounts(hostHomeDir string, containerUser string) []Moun
 		containerHomeDir = "/home/" + containerUser
 	}
 
+	hostClaudePath := filepath.Join(hostHomeDir, ".claude")
+	containerClaudePath := filepath.Join(containerHomeDir, ".claude")
+
+	// If paths are already the same (e.g., Linux with same user), only need one mount
+	if hostClaudePath == containerClaudePath {
+		return []Mount{
+			{
+				HostPath:      hostClaudePath,
+				ContainerPath: containerClaudePath,
+				ReadOnly:      false,
+			},
+		}
+	}
+
+	// Dual mount required: Claude Code finds config at $HOME/.claude, but
+	// installed_plugins.json contains absolute host paths that must resolve.
+	// Mount at both locations so both access patterns work.
 	return []Mount{
 		{
-			HostPath:      filepath.Join(hostHomeDir, ".claude"),
-			ContainerPath: filepath.Join(containerHomeDir, ".claude"),
-			ReadOnly:      false, // Needs write for plugins, etc.
+			HostPath:      hostClaudePath,
+			ContainerPath: hostClaudePath, // Same as host (for plugin absolute paths)
+			ReadOnly:      false,
+		},
+		{
+			HostPath:      hostClaudePath,
+			ContainerPath: containerClaudePath, // At container $HOME (for Claude Code)
+			ReadOnly:      false,
 		},
 	}
 }

--- a/pkg/agents/agent_test.go
+++ b/pkg/agents/agent_test.go
@@ -43,26 +43,84 @@ func TestClaudeAgent(t *testing.T) {
 	if !agent.RequiresSpecialHandling() {
 		t.Error("RequiresSpecialHandling() = false, want true for Claude")
 	}
+}
 
-	// Test mounts with vscode user
-	mounts := agent.GetMounts("/home/test", "vscode")
-	if len(mounts) != 1 {
-		t.Errorf("GetMounts() returned %d mounts, want 1", len(mounts))
-	}
+func TestClaudeAgentDualMount(t *testing.T) {
+	agent := &ClaudeAgent{}
 
-	if mounts[0].HostPath != "/home/test/.claude" {
-		t.Errorf("Mount HostPath = %v, want /home/test/.claude", mounts[0].HostPath)
-	}
+	// macOS-style: host home differs from container home → dual mount
+	t.Run("different paths produces dual mount", func(t *testing.T) {
+		mounts := agent.GetMounts("/Users/testuser", "vscode")
+		if len(mounts) != 2 {
+			t.Fatalf("GetMounts() returned %d mounts, want 2", len(mounts))
+		}
 
-	if mounts[0].ContainerPath != "/home/vscode/.claude" {
-		t.Errorf("Mount ContainerPath = %v, want /home/vscode/.claude", mounts[0].ContainerPath)
-	}
+		// First mount: same-path for absolute plugin path resolution
+		if mounts[0].HostPath != "/Users/testuser/.claude" {
+			t.Errorf("Mount[0] HostPath = %v, want /Users/testuser/.claude", mounts[0].HostPath)
+		}
+		if mounts[0].ContainerPath != "/Users/testuser/.claude" {
+			t.Errorf("Mount[0] ContainerPath = %v, want /Users/testuser/.claude", mounts[0].ContainerPath)
+		}
 
-	// Test mounts with root user
-	rootMounts := agent.GetMounts("/home/test", "root")
-	if rootMounts[0].ContainerPath != "/root/.claude" {
-		t.Errorf("Mount ContainerPath for root = %v, want /root/.claude", rootMounts[0].ContainerPath)
-	}
+		// Second mount: container $HOME for Claude Code discovery
+		if mounts[1].HostPath != "/Users/testuser/.claude" {
+			t.Errorf("Mount[1] HostPath = %v, want /Users/testuser/.claude", mounts[1].HostPath)
+		}
+		if mounts[1].ContainerPath != "/home/vscode/.claude" {
+			t.Errorf("Mount[1] ContainerPath = %v, want /home/vscode/.claude", mounts[1].ContainerPath)
+		}
+
+		// Both should be read-write
+		if mounts[0].ReadOnly || mounts[1].ReadOnly {
+			t.Error("Mounts should be read-write")
+		}
+	})
+
+	// Linux same-user: identical paths → single mount optimization
+	t.Run("identical paths produces single mount", func(t *testing.T) {
+		mounts := agent.GetMounts("/home/vscode", "vscode")
+		if len(mounts) != 1 {
+			t.Fatalf("GetMounts() returned %d mounts, want 1 for identical paths", len(mounts))
+		}
+
+		if mounts[0].HostPath != "/home/vscode/.claude" {
+			t.Errorf("Mount HostPath = %v, want /home/vscode/.claude", mounts[0].HostPath)
+		}
+		if mounts[0].ContainerPath != "/home/vscode/.claude" {
+			t.Errorf("Mount ContainerPath = %v, want /home/vscode/.claude", mounts[0].ContainerPath)
+		}
+	})
+
+	// Root user with different host path → dual mount
+	t.Run("root user produces dual mount", func(t *testing.T) {
+		mounts := agent.GetMounts("/Users/testuser", "root")
+		if len(mounts) != 2 {
+			t.Fatalf("GetMounts() returned %d mounts, want 2", len(mounts))
+		}
+
+		if mounts[0].ContainerPath != "/Users/testuser/.claude" {
+			t.Errorf("Mount[0] ContainerPath = %v, want /Users/testuser/.claude", mounts[0].ContainerPath)
+		}
+		if mounts[1].ContainerPath != "/root/.claude" {
+			t.Errorf("Mount[1] ContainerPath = %v, want /root/.claude", mounts[1].ContainerPath)
+		}
+	})
+
+	// Linux different user → dual mount
+	t.Run("linux different user produces dual mount", func(t *testing.T) {
+		mounts := agent.GetMounts("/home/alice", "vscode")
+		if len(mounts) != 2 {
+			t.Fatalf("GetMounts() returned %d mounts, want 2", len(mounts))
+		}
+
+		if mounts[0].ContainerPath != "/home/alice/.claude" {
+			t.Errorf("Mount[0] ContainerPath = %v, want /home/alice/.claude", mounts[0].ContainerPath)
+		}
+		if mounts[1].ContainerPath != "/home/vscode/.claude" {
+			t.Errorf("Mount[1] ContainerPath = %v, want /home/vscode/.claude", mounts[1].ContainerPath)
+		}
+	})
 }
 
 func TestCodexAgent(t *testing.T) {

--- a/pkg/agents/agent_test.go
+++ b/pkg/agents/agent_test.go
@@ -90,6 +90,24 @@ func TestClaudeAgentDualMount(t *testing.T) {
 		if mounts[0].ContainerPath != "/home/vscode/.claude" {
 			t.Errorf("Mount ContainerPath = %v, want /home/vscode/.claude", mounts[0].ContainerPath)
 		}
+		if mounts[0].ReadOnly {
+			t.Error("Mount should be read-write")
+		}
+	})
+
+	// Root-as-root: identical paths → single mount optimization
+	t.Run("root as root produces single mount", func(t *testing.T) {
+		mounts := agent.GetMounts("/root", "root")
+		if len(mounts) != 1 {
+			t.Fatalf("GetMounts() returned %d mounts, want 1 for root-as-root", len(mounts))
+		}
+
+		if mounts[0].HostPath != "/root/.claude" {
+			t.Errorf("Mount HostPath = %v, want /root/.claude", mounts[0].HostPath)
+		}
+		if mounts[0].ContainerPath != "/root/.claude" {
+			t.Errorf("Mount ContainerPath = %v, want /root/.claude", mounts[0].ContainerPath)
+		}
 	})
 
 	// Root user with different host path → dual mount

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -756,17 +756,6 @@ func Run(config *RunConfig) error {
 		}
 	}
 
-	// Mount .claude directory
-	args = append(args, "-v", fmt.Sprintf("%s/.claude:/home/%s/.claude", homeDir, devConfig.RemoteUser))
-
-	// Overlay mount credential file after .claude directory mount
-	if needsCredentialOverlay {
-		args = append(args, "-v", fmt.Sprintf("%s:/home/%s/.claude/.credentials.json", credentialFile, devConfig.RemoteUser))
-	}
-
-	// Ensure parent directory exists in container by creating it on first run
-	// We'll create it after container starts but before exec
-
 	// Mount workspace - use workspaceMount if specified, otherwise default -v
 	if devConfig.WorkspaceMount != "" {
 		// Validate that workspaceFolder is also set (Microsoft spec requirement)
@@ -806,6 +795,12 @@ func Run(config *RunConfig) error {
 	mountBuilder := NewMountBuilder(homeDir, devConfig.RemoteUser)
 	agentMounts := mountBuilder.BuildAgentMounts()
 	args = append(args, agentMounts...)
+
+	// Overlay mount credential file after .claude directory mount
+	// Must come after BuildAgentMounts() which mounts ~/.claude
+	if needsCredentialOverlay {
+		args = append(args, "-v", fmt.Sprintf("%s:/home/%s/.claude/.credentials.json", credentialFile, devConfig.RemoteUser))
+	}
 
 	// If using a worktree, also mount the main repo's .git directory at its real path
 	// This allows the worktree's .git file (which contains gitdir: <path>) to resolve correctly


### PR DESCRIPTION
Support Claude Code plugins/skills when running via `packnplay run claude`.

The `installed_plugins.json` file contains hardcoded absolute host paths (e.g., `/Users/myuser/.claude/plugins/cache/...`) that don't exist in the container.

This PR implements dual mounting of `~/.claude` at both:
- The container's `$HOME/.claude` path: Where Claude Code discovers its config
- The original host path: Where its config's plugins are referenced

## Motivation and Context

When running `packnplay run claude`, Claude Code plugins and skills fail because:
- `installed_plugins.json` stores absolute host paths to plugin files
- `packnplay` previously only mounted `~/.claude` to `/home/{remoteUser}/.claude`
- Claude Code tries to read files from the original host path (e.g., `/Users/myuser/.claude/plugins/...`), which doesn't exist in the container

This made workflows like `/superpowers:brainstorming` or any installed plugin fail silently inside containers.

## How Has This Been Tested?

Locally:
* Light manual testing via `packnplay run claude` in other projects
* New and updated unit tests for `ClaudeAgent.GetMounts()` covering:
    * macOS-style different paths → dual mount
    * Linux same-user identical paths → single mount (optimization)
    * Root user scenarios → correct `/root/.claude` path
    * Linux different user → dual mount
* Ran `make test`: Same pass/fail as main branch
    * Also, ran `make test` with `AlexEdgcomb:fix/test-failures` merged in and all passed
* With `AlexEdgcomb:fix/golangci-lint-v2-config` merged in, ran:
    * Ran `make lint`: 0 issues
    * Ran `golangci-lint fmt`: 0 issues

## Breaking Changes

None. The dual mount approach is additive.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- Dual mount chosen over alternatives (symlinks, path rewriting, `CLAUDE_CONFIG_DIR` env var) for simplicity and transparency
- Single mount optimization when paths are identical (e.g., Linux with same user) to avoid unnecessary duplicate mounts
- Removed redundant hardcoded `.claude` mount from `runner.go` - now handled entirely through the agent mount abstraction
- Credential overlay mount ordering preserved (must come after `~/.claude` mount)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude plugin discovery with enhanced path mounting strategy, ensuring plugins are reliably resolved across different environments and user configurations.

* **Tests**
  * Expanded test coverage for plugin discovery across macOS, Linux, root-user, and multi-user scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->