### PR TITLE
feat: add -v/--volume CLI flag for ad-hoc volume mounts

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -24,6 +24,7 @@ var (
 	runConfig       string
 	runReconnect    bool
 	runPublishPorts []string
+	runVolumes      []string
 	// Credential flags
 	runGitCreds *bool
 	runSSHCreds *bool
@@ -153,6 +154,7 @@ var runCmd = &cobra.Command{
 			Credentials:    creds,
 			DefaultEnvVars: cfg.DefaultEnvVars,
 			PublishPorts:   runPublishPorts,
+			Volumes:        runVolumes,
 			HostPath:       hostPath,
 			LaunchCommand:  launchCommand,
 		}
@@ -180,6 +182,7 @@ func init() {
 	runCmd.Flags().BoolVar(&runNoWorktree, "no-worktree", false, "Skip worktree, use directory directly")
 	runCmd.Flags().StringSliceVar(&runEnv, "env", []string{}, "Additional env vars (KEY=value)")
 	runCmd.Flags().StringArrayVarP(&runPublishPorts, "publish", "p", []string{}, "Publish container port(s) to host (format: [hostIP:]hostPort:containerPort[/protocol])")
+	runCmd.Flags().StringArrayVarP(&runVolumes, "volume", "v", []string{}, "Bind mount a volume (format: hostPath:containerPath[:options])")
 	runCmd.Flags().StringVar(&runRuntime, "runtime", "", "Container runtime to use (docker/podman/container)")
 	runCmd.Flags().StringVar(&runConfig, "config", "", "API config profile (anthropic, z.ai, anthropic-work, claude-personal)")
 	runCmd.Flags().BoolVarP(&runReconnect, "reconnect", "r", false, "Reconnect to existing container instead of failing")

--- a/cmd/run_volume_test.go
+++ b/cmd/run_volume_test.go
@@ -1,0 +1,147 @@
+// ABOUTME: Tests for the -v/--volume CLI flag for bind-mounting volumes into containers.
+// ABOUTME: Mirrors run_port_test.go pattern for the -p/--publish flag.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/obra/packnplay/pkg/config"
+	"github.com/obra/packnplay/pkg/runner"
+)
+
+func TestRunVolumeFlag(t *testing.T) {
+	runVolumes = []string{}
+
+	err := runCmd.ParseFlags([]string{"-v", "/tmp/test:/test"})
+	if err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	if len(runVolumes) != 1 {
+		t.Errorf("Expected 1 volume mount, got %d", len(runVolumes))
+	}
+
+	if runVolumes[0] != "/tmp/test:/test" {
+		t.Errorf("Expected volume mount '/tmp/test:/test', got '%s'", runVolumes[0])
+	}
+}
+
+func TestRunMultipleVolumeFlags(t *testing.T) {
+	runVolumes = []string{}
+
+	err := runCmd.ParseFlags([]string{"-v", "/tmp/a:/a", "-v", "/tmp/b:/b", "-v", "/tmp/c:/c"})
+	if err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	if len(runVolumes) != 3 {
+		t.Errorf("Expected 3 volume mounts, got %d", len(runVolumes))
+	}
+
+	expected := []string{"/tmp/a:/a", "/tmp/b:/b", "/tmp/c:/c"}
+	for i, exp := range expected {
+		if i >= len(runVolumes) {
+			t.Errorf("Missing volume mount at index %d", i)
+			continue
+		}
+		if runVolumes[i] != exp {
+			t.Errorf("Expected volume mount '%s' at index %d, got '%s'", exp, i, runVolumes[i])
+		}
+	}
+}
+
+func TestDockerCompatibleVolumeFormats(t *testing.T) {
+	tests := []struct {
+		name     string
+		flags    []string
+		expected []string
+	}{
+		{
+			name:     "host path to container path",
+			flags:    []string{"-v", "/host:/container"},
+			expected: []string{"/host:/container"},
+		},
+		{
+			name:     "read-only mount",
+			flags:    []string{"-v", "/host:/container:ro"},
+			expected: []string{"/host:/container:ro"},
+		},
+		{
+			name:     "named volume",
+			flags:    []string{"-v", "myvolume:/data"},
+			expected: []string{"myvolume:/data"},
+		},
+		{
+			name:     "bare absolute path",
+			flags:    []string{"-v", "/data"},
+			expected: []string{"/data"},
+		},
+		{
+			name:     "read-write explicit",
+			flags:    []string{"-v", "/host:/container:rw"},
+			expected: []string{"/host:/container:rw"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runVolumes = []string{}
+
+			err := runCmd.ParseFlags(tt.flags)
+			if err != nil {
+				t.Fatalf("ParseFlags() error = %v", err)
+			}
+
+			if len(runVolumes) != len(tt.expected) {
+				t.Errorf("Expected %d volume mounts, got %d", len(tt.expected), len(runVolumes))
+			}
+
+			for i, exp := range tt.expected {
+				if i >= len(runVolumes) {
+					t.Errorf("Missing volume mount at index %d", i)
+					continue
+				}
+				if runVolumes[i] != exp {
+					t.Errorf("Expected volume mount '%s' at index %d, got '%s'", exp, i, runVolumes[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRunConfigIncludesVolumes(t *testing.T) {
+	runVolumes = []string{}
+
+	err := runCmd.ParseFlags([]string{"-v", "/tmp/a:/a", "-v", "/tmp/b:/b", "echo", "hello"})
+	if err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+
+	cfg := &config.Config{
+		ContainerRuntime: "docker",
+		DefaultImage:     "ubuntu:22.04",
+	}
+
+	runConfig := &runner.RunConfig{
+		Runtime:      cfg.ContainerRuntime,
+		DefaultImage: cfg.DefaultImage,
+		Command:      []string{"echo", "hello"},
+		Volumes:      runVolumes,
+	}
+
+	if len(runConfig.Volumes) != 2 {
+		t.Errorf("Expected 2 volume mounts in RunConfig, got %d", len(runConfig.Volumes))
+	}
+
+	expected := []string{"/tmp/a:/a", "/tmp/b:/b"}
+	for i, exp := range expected {
+		if i >= len(runConfig.Volumes) {
+			t.Errorf("Missing volume mount at index %d", i)
+			continue
+		}
+		if runConfig.Volumes[i] != exp {
+			t.Errorf("Expected volume mount '%s' at index %d in RunConfig, got '%s'", exp, i, runConfig.Volumes[i])
+		}
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -39,6 +39,7 @@ type RunConfig struct {
 	Credentials           config.Credentials
 	DefaultEnvVars        []string                        // API keys to proxy from host
 	PublishPorts          []string                        // Port mappings to publish to host
+	Volumes               []string                        // Volume mounts from CLI -v flags
 	HostPath              string                          // Host directory path for the container
 	LaunchCommand         string                          // Original command line used to launch
 	WorkspaceMount        string                          // Custom workspace mount (Docker --mount syntax)
@@ -564,6 +565,9 @@ func Run(config *RunConfig) error {
 		}
 
 		// User explicitly wants to reconnect
+		if warning := ignoredCreationFlags(config); warning != "" {
+			fmt.Fprintln(os.Stderr, warning)
+		}
 		if config.Verbose {
 			fmt.Fprintf(os.Stderr, "Reconnecting to existing container %s\n", containerName)
 		}
@@ -614,6 +618,9 @@ func Run(config *RunConfig) error {
 
 		if err == nil && runningCheck == "" {
 			// Container exists but is not running - try to restart it
+			if warning := ignoredCreationFlags(config); warning != "" {
+				fmt.Fprintln(os.Stderr, warning)
+			}
 			if config.Verbose {
 				fmt.Fprintf(os.Stderr, "Found stopped container %s, attempting to restart...\n", containerName)
 			}
@@ -1101,6 +1108,11 @@ func Run(config *RunConfig) error {
 
 		// Add as Docker mount flag
 		args = append(args, "--mount", substitutedMount)
+	}
+
+	// Add CLI volume mounts (-v flags)
+	for _, vol := range config.Volumes {
+		args = append(args, "-v", normalizeVolume(vol))
 	}
 
 	// Add user for container operations (docker run --user)
@@ -2421,6 +2433,42 @@ func executeHostCommandsParallel(commands map[string]interface{}, workDir string
 		errMsg += fmt.Sprintf("\n  - %s", err.Error())
 	}
 	return fmt.Errorf("%s", errMsg)
+}
+
+// ignoredCreationFlags returns a warning message listing CLI flags that only
+// apply at container creation time. Returns empty string if none are set.
+func ignoredCreationFlags(config *RunConfig) string {
+	var flags []string
+	if len(config.Volumes) > 0 {
+		flags = append(flags, "-v/--volume")
+	}
+	if len(config.PublishPorts) > 0 {
+		flags = append(flags, "-p/--publish")
+	}
+	if len(flags) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("Warning: %s flags are ignored when reusing an existing container (they only apply at creation time).\nTo apply new flags, stop the container first with: packnplay stop", strings.Join(flags, ", "))
+}
+
+// normalizeVolume expands shorthand volume specs to full Docker -v syntax.
+// A bare path (no colon) becomes a same-path bind mount (PATH:PATH).
+// Relative bare paths are resolved to absolute paths.
+// A leading colon (:PATH) creates an anonymous volume at PATH.
+func normalizeVolume(vol string) string {
+	if strings.HasPrefix(vol, ":") {
+		return vol[1:]
+	}
+	if !strings.Contains(vol, ":") {
+		resolved := vol
+		if !filepath.IsAbs(vol) {
+			if abs, err := filepath.Abs(vol); err == nil {
+				resolved = abs
+			}
+		}
+		return resolved + ":" + resolved
+	}
+	return vol
 }
 
 // validateHostRequirements checks if the host meets minimum requirements

--- a/pkg/runner/volume_test.go
+++ b/pkg/runner/volume_test.go
@@ -1,0 +1,142 @@
+// ABOUTME: Tests for CLI volume handling: normalization and reconnect warnings.
+// ABOUTME: Verifies shorthand expansion, relative path resolution, and ignored-flag warnings.
+
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeVolume(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "bare path becomes same-path bind mount",
+			input:    "/Users/clkao/git/noteplan-plugin",
+			expected: "/Users/clkao/git/noteplan-plugin:/Users/clkao/git/noteplan-plugin",
+		},
+		{
+			name:     "leading colon creates anonymous volume",
+			input:    ":/data",
+			expected: "/data",
+		},
+		{
+			name:     "host:container passed through",
+			input:    "/host/path:/container/path",
+			expected: "/host/path:/container/path",
+		},
+		{
+			name:     "host:container:options passed through",
+			input:    "/host/path:/container/path:ro",
+			expected: "/host/path:/container/path:ro",
+		},
+		{
+			name:     "named volume passed through",
+			input:    "myvolume:/data",
+			expected: "myvolume:/data",
+		},
+		{
+			name:     "named volume with options passed through",
+			input:    "myvolume:/data:ro",
+			expected: "myvolume:/data:ro",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeVolume(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeVolume(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIgnoredCreationFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       *RunConfig
+		wantWarnings []string
+		wantNone     bool
+	}{
+		{
+			name:     "no flags set",
+			config:   &RunConfig{},
+			wantNone: true,
+		},
+		{
+			name:         "volumes ignored",
+			config:       &RunConfig{Volumes: []string{"/tmp:/tmp"}},
+			wantWarnings: []string{"-v/--volume"},
+		},
+		{
+			name:         "ports ignored",
+			config:       &RunConfig{PublishPorts: []string{"8080:80"}},
+			wantWarnings: []string{"-p/--publish"},
+		},
+		{
+			name:         "both ignored",
+			config:       &RunConfig{Volumes: []string{"/a:/a"}, PublishPorts: []string{"3000:3000"}},
+			wantWarnings: []string{"-v/--volume", "-p/--publish"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := ignoredCreationFlags(tt.config)
+			if tt.wantNone {
+				if msg != "" {
+					t.Errorf("expected no warning, got %q", msg)
+				}
+				return
+			}
+			if msg == "" {
+				t.Fatal("expected warning, got empty string")
+			}
+			for _, want := range tt.wantWarnings {
+				if !strings.Contains(msg, want) {
+					t.Errorf("warning %q missing expected substring %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeVolumeRelativePath(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "relative path resolved to absolute",
+			input:    "data",
+			expected: filepath.Join(cwd, "data") + ":" + filepath.Join(cwd, "data"),
+		},
+		{
+			name:     "dot-relative path resolved to absolute",
+			input:    "./mydir",
+			expected: filepath.Join(cwd, "mydir") + ":" + filepath.Join(cwd, "mydir"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeVolume(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeVolume(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why this matters

Previously, mounting a host directory into a container required editing `devcontainer.json`. If you just wanted to quickly share a directory with your container — e.g. `packnplay run -v /Users/me/data claude` — there was no CLI option for it.

Worse, passing `-v /some/path` to Docker without a `:destination` creates an **empty anonymous volume** instead of a bind mount, which is confusing and hard to debug (the directory appears to exist inside the container but is empty).

This PR adds `-v`/`--volume` following the same pattern as the existing `-p`/`--publish` flag, with smart defaults that do the right thing:

- **`-v /path`** mounts as `/path:/path` — the most common case just works
- **`-v /host:/container`** standard Docker syntax passes through
- **`-v /host:/container:ro`** mount options supported
- **Relative paths** (e.g. `-v ./data`) are resolved to absolute automatically
- **`-v :PATH`** explicitly creates an anonymous volume (opt-in, not accidental)
- **Reconnect warning** — if you pass `-v` or `-p` with `--reconnect` or hit a stopped container restart, you now get a clear warning that those flags only apply at creation time

## Summary

- Add `--volume`/`-v` `StringArrayVarP` flag in `cmd/run.go`
- Add `Volumes` field to `RunConfig`, emit `-v` Docker args after devcontainer.json mounts
- Add `normalizeVolume()` for bare-path expansion and relative path resolution
- Add `ignoredCreationFlags()` warning for reconnect/restart paths
- Comprehensive unit tests for flag parsing, normalization, relative paths, and warning logic

## Test plan

- [x] `go test ./cmd/ -run Volume` — flag parsing tests pass
- [x] `go test ./pkg/runner/ -run "NormalizeVolume|IgnoredCreation"` — normalization and warning tests pass
- [x] `go test ./...` — no regressions (only pre-existing Docker-dependent integration test fails)
- [ ] Manual: `packnplay run -v /tmp/test claude` mounts `/tmp/test` into container at same path
- [ ] Manual: `packnplay run --reconnect -v /new/path claude` shows warning about ignored flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--volume` (or `-v`) CLI flag to bind volumes when running containers
  * Supports Docker-compatible volume formats including host:container mappings, named volumes, read-only mounts, and absolute paths

* **Improvements**
  * Added warnings when volume configurations are present but existing containers are being reused

<!-- end of auto-generated comment: release notes by coderabbit.ai -->