### PR TITLE
fix: re-seed container credentials when file is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ I built packnplay as a lightweight container/worktree launcher for my coding age
 - **Credential Management**: Interactive first-run setup for git, GitHub CLI, GPG, npm, and AWS credentials
 - **AWS Credentials Support**: Intelligent handling of AWS credentials including SSO, credential_process (granted.dev, aws-vault), and static credentials
 - **Clean Environment**: Only passes safe environment variables (terminal/locale), no host pollution
-- **macOS Keychain Integration**: Automatically extracts Claude and GitHub CLI credentials from macOS Keychain
+- **macOS Keychain Integration**: Automatically extracts GitHub CLI credentials from macOS Keychain, stores container-specific Claude credentials
 
 ## Installation
 
@@ -369,7 +369,7 @@ On first run, packnplay prompts you to choose which credentials to enable by def
 - **npm**: `~/.npmrc` (for authenticated package operations)
 
 **macOS Keychain Integration:**
-- Claude credentials automatically extracted from Keychain (`Claude Code-credentials`)
+- Claude container credentials stored in Keychain (`packnplay-containers-credentials`) after first `claude login` inside a container
 - GitHub CLI credentials extracted and base64-decoded from Keychain (`gh:github.com`)
 - Credentials copied into container (not mounted) to avoid file locking
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2177,9 +2177,8 @@ func getOrCreateContainerCredentialFile(containerName string) (string, error) {
 	}
 	credentialFile := filepath.Join(credentialsDir, "claude-credentials.json")
 
-	// If file doesn't exist, initialize it
-	if !fileExists(credentialFile) {
-		// Try to get initial credentials from keychain (macOS) or copy from host (Linux)
+	// Seed credentials if file is missing or empty (e.g. leftover from a failed prior attempt)
+	if getFileSize(credentialFile) < 20 {
 		initialCreds, err := getInitialContainerCredentials()
 		if err != nil {
 			// Create empty file - user will need to authenticate in container


### PR DESCRIPTION
## Summary

- Empty credential files (`{}`) from failed prior attempts are now re-seeded instead of being left stale
- Previously, `getOrCreateContainerCredentialFile` only checked if the file existed, not whether it contained valid credentials
- Now uses a `< 20 byte` threshold to detect empty/stub credential files and re-seed them from keychain (macOS) or host credentials (Linux)

## Test plan

- [ ] Delete `~/.local/share/packnplay/credentials/claude-credentials.json` and run `packnplay run claude` — credentials should be seeded
- [ ] Create an empty `claude-credentials.json` containing `{}`, run `packnplay run claude` — file should be re-seeded
- [ ] With a valid credential file (> 20 bytes), verify it is left untouched

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential file recovery to handle incomplete or corrupted files from previous failed attempts.

* **Documentation**
  * Clarified macOS Keychain credential handling behavior for GitHub CLI and Claude authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->