### PR TITLE
fix: Colima and non-Docker-Desktop runtime compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,14 +364,12 @@ On first run, packnplay prompts you to choose which credentials to enable by def
 **Credentials are mounted read-only for security:**
 - **Git**: `~/.gitconfig` (git user configuration)
 - **SSH**: `~/.ssh` (SSH keys for authentication to servers and repos)
-- **GitHub CLI**: `~/.config/gh` (copied from Keychain on macOS, mounted on Linux)
+- **GitHub CLI**: `~/.config/gh` (GitHub CLI authentication)
 - **GPG**: `~/.gnupg` (for commit signing)
 - **npm**: `~/.npmrc` (for authenticated package operations)
 
 **macOS Keychain Integration:**
 - Claude credentials automatically extracted from Keychain (`Claude Code-credentials`)
-- GitHub CLI credentials extracted and base64-decoded from Keychain (`gh:github.com`)
-- Credentials copied into container (not mounted) to avoid file locking
 
 ### File Mounts
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ packnplay mounts your project at the **exact same path** inside the container as
 
 ## Requirements
 
-- **Docker**: Docker Desktop on macOS, or Docker Engine on Linux
+- **Docker**: Docker Desktop, Colima, or Podman on macOS; Docker Engine on Linux
 - **Git**: For worktree functionality
 - **Go 1.23+**: For building from source
 - **Optional**: GitHub CLI (`gh`) for GitHub operations

--- a/internal/dockerfile/dockerfile_generator.go
+++ b/internal/dockerfile/dockerfile_generator.go
@@ -52,7 +52,7 @@ func (g *DockerfileGenerator) generateMultiStage(baseImage string, features []*d
 			// OCI feature - needs to be copied from absolute path
 			// We'll use a build arg to pass the feature path at build time
 			featureDestPath := fmt.Sprintf("/tmp/features/%d-%s", i, feature.ID)
-			sb.WriteString(fmt.Sprintf("# Copy OCI feature: %s\n", feature.ID))
+			fmt.Fprintf(&sb, "# Copy OCI feature: %s\n", feature.ID)
 
 			// For OCI features in cache, we need to use COPY with the relative path from build context
 			// But since they're outside the build context, we use a workaround:
@@ -61,19 +61,19 @@ func (g *DockerfileGenerator) generateMultiStage(baseImage string, features []*d
 			if strings.Contains(feature.InstallPath, "oci-cache") {
 				relPath = filepath.Join("oci-cache", filepath.Base(feature.InstallPath))
 			}
-			sb.WriteString(fmt.Sprintf("COPY %s %s\n", relPath, featureDestPath))
+			fmt.Fprintf(&sb, "COPY %s %s\n", relPath, featureDestPath)
 		}
 	}
 	sb.WriteString("\n")
 
 	// Stage 2: Base image with features
-	sb.WriteString(fmt.Sprintf("FROM %s as base\n", baseImage))
+	fmt.Fprintf(&sb, "FROM %s as base\n", baseImage)
 	sb.WriteString("USER root\n")
 
 	// Add user context environment variables
-	sb.WriteString(fmt.Sprintf("ENV _REMOTE_USER=%s\n", remoteUser))
-	sb.WriteString(fmt.Sprintf("ENV _REMOTE_USER_HOME=/home/%s\n", remoteUser))
-	sb.WriteString(fmt.Sprintf("ENV _CONTAINER_USER=%s\n\n", remoteUser))
+	fmt.Fprintf(&sb, "ENV _REMOTE_USER=%s\n", remoteUser)
+	fmt.Fprintf(&sb, "ENV _REMOTE_USER_HOME=/home/%s\n", remoteUser)
+	fmt.Fprintf(&sb, "ENV _CONTAINER_USER=%s\n\n", remoteUser)
 
 	// Copy features from prep stage
 	sb.WriteString("# Copy features from prep stage\n")
@@ -82,7 +82,7 @@ func (g *DockerfileGenerator) generateMultiStage(baseImage string, features []*d
 	// Install features with options processing
 	processor := devcontainer.NewFeatureOptionsProcessor()
 	for i, feature := range features {
-		sb.WriteString(fmt.Sprintf("# Install feature: %s\n", feature.ID))
+		fmt.Fprintf(&sb, "# Install feature: %s\n", feature.ID)
 
 		// Add environment variables from options
 		if feature.Metadata != nil && feature.Metadata.Options != nil {
@@ -91,24 +91,24 @@ func (g *DockerfileGenerator) generateMultiStage(baseImage string, features []*d
 				return "", fmt.Errorf("invalid options for feature %s: %w", feature.ID, err)
 			}
 			for envName, envValue := range envVars {
-				sb.WriteString(fmt.Sprintf("ENV %s=%s\n", envName, envValue))
+				fmt.Fprintf(&sb, "ENV %s=%s\n", envName, envValue)
 			}
 		}
 
 		// Add feature-contributed container environment variables
 		if feature.Metadata != nil && feature.Metadata.ContainerEnv != nil {
 			for envName, envValue := range feature.Metadata.ContainerEnv {
-				sb.WriteString(fmt.Sprintf("ENV %s=%s\n", envName, envValue))
+				fmt.Fprintf(&sb, "ENV %s=%s\n", envName, envValue)
 			}
 		}
 
 		featureDestPath := fmt.Sprintf("/tmp/devcontainer-features/%d-%s", i, feature.ID)
-		sb.WriteString(fmt.Sprintf("RUN cd %s && chmod +x install.sh && ./install.sh\n\n", featureDestPath))
+		fmt.Fprintf(&sb, "RUN cd %s && chmod +x install.sh && ./install.sh\n\n", featureDestPath)
 	}
 
 	// Switch to user
 	if remoteUser != "" {
-		sb.WriteString(fmt.Sprintf("USER %s\n", remoteUser))
+		fmt.Fprintf(&sb, "USER %s\n", remoteUser)
 	}
 	sb.WriteString("WORKDIR /workspace\n")
 
@@ -120,20 +120,20 @@ func (g *DockerfileGenerator) generateSingleStage(baseImage string, features []*
 	var sb strings.Builder
 
 	// FROM statement
-	sb.WriteString(fmt.Sprintf("FROM %s\n\n", baseImage))
+	fmt.Fprintf(&sb, "FROM %s\n\n", baseImage)
 
 	// Switch to root for installation
 	sb.WriteString("USER root\n")
 
 	// Add user context environment variables
-	sb.WriteString(fmt.Sprintf("ENV _REMOTE_USER=%s\n", remoteUser))
-	sb.WriteString(fmt.Sprintf("ENV _REMOTE_USER_HOME=/home/%s\n", remoteUser))
-	sb.WriteString(fmt.Sprintf("ENV _CONTAINER_USER=%s\n\n", remoteUser))
+	fmt.Fprintf(&sb, "ENV _REMOTE_USER=%s\n", remoteUser)
+	fmt.Fprintf(&sb, "ENV _REMOTE_USER_HOME=/home/%s\n", remoteUser)
+	fmt.Fprintf(&sb, "ENV _CONTAINER_USER=%s\n\n", remoteUser)
 
 	// Install features
 	processor := devcontainer.NewFeatureOptionsProcessor()
 	for i, feature := range features {
-		sb.WriteString(fmt.Sprintf("# Install feature: %s\n", feature.ID))
+		fmt.Fprintf(&sb, "# Install feature: %s\n", feature.ID)
 
 		// Process feature options to environment variables
 		if feature.Metadata != nil && feature.Metadata.Options != nil {
@@ -142,14 +142,14 @@ func (g *DockerfileGenerator) generateSingleStage(baseImage string, features []*
 				return "", fmt.Errorf("invalid options for feature %s: %w", feature.ID, err)
 			}
 			for envName, envValue := range envVars {
-				sb.WriteString(fmt.Sprintf("ENV %s=%s\n", envName, envValue))
+				fmt.Fprintf(&sb, "ENV %s=%s\n", envName, envValue)
 			}
 		}
 
 		// Add feature-contributed container environment variables
 		if feature.Metadata != nil && feature.Metadata.ContainerEnv != nil {
 			for envName, envValue := range feature.Metadata.ContainerEnv {
-				sb.WriteString(fmt.Sprintf("ENV %s=%s\n", envName, envValue))
+				fmt.Fprintf(&sb, "ENV %s=%s\n", envName, envValue)
 			}
 		}
 
@@ -166,15 +166,15 @@ func (g *DockerfileGenerator) generateSingleStage(baseImage string, features []*
 		}
 
 		featureDestPath := fmt.Sprintf("/tmp/devcontainer-features/%d-%s", i, feature.ID)
-		sb.WriteString(fmt.Sprintf("COPY %s %s\n", relPath, featureDestPath))
+		fmt.Fprintf(&sb, "COPY %s %s\n", relPath, featureDestPath)
 
 		// Run the install script from its directory so relative paths work
-		sb.WriteString(fmt.Sprintf("RUN cd %s && chmod +x install.sh && ./install.sh\n\n", featureDestPath))
+		fmt.Fprintf(&sb, "RUN cd %s && chmod +x install.sh && ./install.sh\n\n", featureDestPath)
 	}
 
 	// Switch back to remote user if specified
 	if remoteUser != "" {
-		sb.WriteString(fmt.Sprintf("USER %s\n", remoteUser))
+		fmt.Fprintf(&sb, "USER %s\n", remoteUser)
 	}
 	sb.WriteString("WORKDIR /workspace\n")
 

--- a/pkg/runner/e2e_test.go
+++ b/pkg/runner/e2e_test.go
@@ -3753,14 +3753,10 @@ func TestE2E_HostRequirements_Warning(t *testing.T) {
 }
 
 // TestE2E_UpdateRemoteUserUID verifies that updateRemoteUserUID syncs container
-// user UID/GID to match host user on Linux (skipped on macOS/Windows)
+// user UID/GID to match host user
 func TestE2E_UpdateRemoteUserUID(t *testing.T) {
 	skipIfNoDocker(t)
 
-	// Skip on non-Linux platforms (Docker Desktop handles this automatically)
-	if runtime.GOOS != "linux" {
-		t.Skip("updateRemoteUserUID is Linux-only (Docker Desktop handles UID/GID mapping automatically)")
-	}
 	if isCI() {
 		t.Skip("updateRemoteUserUID feature does not remap UID when user already exists with different UID - feature bug")
 	}
@@ -3808,23 +3804,38 @@ func TestE2E_UpdateRemoteUserUID(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%d", hostGID), containerGID, "Container user GID should match host GID")
 }
 
-// TestE2E_UpdateRemoteUserUID_NotOnMacOS verifies that updateRemoteUserUID
-// is skipped on macOS (where Docker Desktop handles UID/GID mapping)
-func TestE2E_UpdateRemoteUserUID_NotOnMacOS(t *testing.T) {
+// TestE2E_GitSafeDirectory verifies that git operations work inside containers
+// even when the workspace is owned by a different UID than the container user.
+// Without safe.directory configuration, git refuses to operate with
+// "fatal: detected dubious ownership in repository" errors.
+func TestE2E_GitSafeDirectory(t *testing.T) {
 	skipIfNoDocker(t)
 
-	// Only run on macOS
-	if runtime.GOOS != "darwin" {
-		t.Skip("This test verifies macOS-specific behavior")
-	}
-
-	projectDir := createTestProject(t, map[string]string{
-		".devcontainer/devcontainer.json": `{
-  "image": "alpine:latest",
-  "updateRemoteUserUID": true
-}`,
-	})
+	// Create temp dir under user's home so it's accessible inside VM-based Docker
+	// runtimes (Colima, etc.) which may only share /Users, not /var/folders
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	projectDir, err := os.MkdirTemp(homeDir, "packnplay-e2e-safedir-*")
+	require.NoError(t, err)
 	defer os.RemoveAll(projectDir)
+
+	// Write devcontainer.json
+	dcDir := filepath.Join(projectDir, ".devcontainer")
+	require.NoError(t, os.MkdirAll(dcDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dcDir, "devcontainer.json"), []byte(`{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "remoteUser": "vscode"
+}`), 0644))
+
+	// Initialize a git repo in the project directory so it's mounted into the container
+	cmd := exec.Command("git", "init")
+	cmd.Dir = projectDir
+	require.NoError(t, cmd.Run(), "Failed to init git repo in test project")
+	cmd = exec.Command("git", "commit", "--allow-empty", "-m", "init")
+	cmd.Dir = projectDir
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	require.NoError(t, cmd.Run(), "Failed to create initial commit")
 
 	containerName := getContainerNameForProject(projectDir)
 	defer cleanupContainer(t, containerName)
@@ -3835,11 +3846,62 @@ func TestE2E_UpdateRemoteUserUID_NotOnMacOS(t *testing.T) {
 		}
 	}()
 
-	// Run should succeed and skip UID/GID sync
-	output, err := runPacknplayInDir(t, projectDir, "run", "--no-worktree", "echo", "works")
-	require.NoError(t, err, "Container should start successfully")
-	require.Contains(t, output, "works", "Container should run normally")
-	// We don't check for a skip message - just verify it doesn't error
+	// git log should succeed without "dubious ownership" error
+	output, err := runPacknplayInDir(t, projectDir, "run", "--no-worktree", "git", "log", "--oneline", "-1")
+	require.NoError(t, err, "git should work inside container without safe.directory errors: %s", output)
+	require.Contains(t, output, "init", "Should see the initial commit")
+}
+
+// TestE2E_GHCredsMount verifies that --gh-creds mounts ~/.config/gh on all platforms.
+// Previously this was gated by isLinux which silently skipped the mount on macOS.
+func TestE2E_GHCredsMount(t *testing.T) {
+	skipIfNoDocker(t)
+
+	// Create ~/.config/gh with a marker file if it doesn't exist
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	ghConfigDir := filepath.Join(homeDir, ".config", "gh")
+	createdGHDir := false
+	if !fileExists(ghConfigDir) {
+		require.NoError(t, os.MkdirAll(ghConfigDir, 0755))
+		createdGHDir = true
+	}
+	markerFile := filepath.Join(ghConfigDir, "packnplay-test-marker")
+	require.NoError(t, os.WriteFile(markerFile, []byte("gh-creds-test\n"), 0644))
+	defer os.Remove(markerFile)
+	defer func() {
+		if createdGHDir {
+			os.RemoveAll(ghConfigDir)
+		}
+	}()
+
+	// Create temp dir under user's home so it's accessible inside VM-based Docker
+	// runtimes (Colima, etc.) which may only share /Users, not /var/folders
+	projectDir, err := os.MkdirTemp(homeDir, "packnplay-e2e-ghcreds-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(projectDir)
+
+	// Write devcontainer.json
+	dcDir := filepath.Join(projectDir, ".devcontainer")
+	require.NoError(t, os.MkdirAll(dcDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dcDir, "devcontainer.json"), []byte(`{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "remoteUser": "vscode"
+}`), 0644))
+
+	containerName := getContainerNameForProject(projectDir)
+	defer cleanupContainer(t, containerName)
+	defer func() {
+		containerID := getContainerIDByName(t, containerName)
+		if containerID != "" {
+			cleanupMetadata(t, containerID)
+		}
+	}()
+
+	output, err := runPacknplayInDir(t, projectDir, "run", "--no-worktree", "--gh-creds",
+		"cat", "/home/vscode/.config/gh/packnplay-test-marker")
+	require.NoError(t, err, "gh config should be mounted in container: %s", output)
+	require.Contains(t, output, "gh-creds-test", "Should see the marker file from ~/.config/gh")
 }
 
 // TestE2E_OverrideCommand_False verifies that overrideCommand: false runs container CMD

--- a/pkg/runner/e2e_test.go
+++ b/pkg/runner/e2e_test.go
@@ -3826,6 +3826,8 @@ func TestE2E_GitSafeDirectory(t *testing.T) {
 	projectDir, err := os.MkdirTemp(homeDir, "packnplay-e2e-safedir-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(projectDir)
+	// MkdirTemp creates with 0700; widen so non-root container users can read
+	require.NoError(t, os.Chmod(projectDir, 0755))
 
 	// Write devcontainer.json
 	dcDir := filepath.Join(projectDir, ".devcontainer")

--- a/pkg/runner/e2e_test.go
+++ b/pkg/runner/e2e_test.go
@@ -53,8 +53,14 @@ func isDockerAvailable() bool {
 func createTestProject(t *testing.T, files map[string]string) string {
 	t.Helper()
 
-	// Create temp directory
-	projectDir, err := os.MkdirTemp("", "packnplay-e2e-*")
+	// Create temp directory under $HOME so it's accessible to all container
+	// runtimes. Colima and Podman only share /Users by default, so /var/folders
+	// (which resolves to /private/var/folders on macOS) is not mountable.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("Failed to get home directory: %v", err)
+	}
+	projectDir, err := os.MkdirTemp(homeDir, "packnplay-e2e-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -1904,8 +1910,10 @@ RUN echo "build options test" > /options-test.txt`,
 func TestE2E_CustomMounts(t *testing.T) {
 	skipIfNoDocker(t)
 
-	// Create test directory with content
-	testDataDir, err := os.MkdirTemp("", "packnplay-mount-test-*")
+	// Create test directory under $HOME so it's mountable by all runtimes
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	testDataDir, err := os.MkdirTemp(homeDir, "packnplay-mount-test-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDataDir)
 

--- a/pkg/runner/e2e_test.go
+++ b/pkg/runner/e2e_test.go
@@ -3881,7 +3881,7 @@ func TestE2E_GHCredsMount(t *testing.T) {
 	defer os.Remove(markerFile)
 	defer func() {
 		if createdGHDir {
-			os.RemoveAll(ghConfigDir)
+			os.Remove(ghConfigDir)
 		}
 	}()
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -515,7 +515,7 @@ func Run(config *RunConfig) error {
 					cmdStr.WriteString(" ")
 				}
 				if strings.Contains(arg, " ") {
-					cmdStr.WriteString(fmt.Sprintf("'%s'", arg))
+					fmt.Fprintf(&cmdStr, "'%s'", arg)
 				} else {
 					cmdStr.WriteString(arg)
 				}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -855,9 +855,8 @@ func Run(config *RunConfig) error {
 		warnSSHInsteadOfRules()
 	}
 
-	// Note: On macOS, gh credentials from Keychain are copied in after container starts
-	// On Linux, mount the gh config directory if it exists
-	if config.Credentials.GH && isLinux {
+	// Mount GitHub CLI config directory if it exists
+	if config.Credentials.GH {
 		ghConfigPath := filepath.Join(homeDir, ".config", "gh")
 		if fileExists(ghConfigPath) {
 			args = append(args, "-v", fmt.Sprintf("%s:/home/%s/.config/gh", ghConfigPath, devConfig.RemoteUser))
@@ -1000,6 +999,14 @@ func Run(config *RunConfig) error {
 
 	// Add IS_SANDBOX marker so tools know they're in a sandbox
 	args = append(args, "-e", "IS_SANDBOX=1")
+
+	// Configure git safe.directory to prevent "dubious ownership" errors
+	// when container user UID differs from mounted workspace file ownership
+	// (common with Colima, Podman, and other non-Docker-Desktop runtimes).
+	// Uses GIT_CONFIG_COUNT mechanism, additive to the mounted read-only .gitconfig.
+	args = append(args, "-e", "GIT_CONFIG_COUNT=1")
+	args = append(args, "-e", "GIT_CONFIG_KEY_0=safe.directory")
+	args = append(args, "-e", "GIT_CONFIG_VALUE_0=*")
 
 	// Don't set PATH - use container's default PATH to avoid host pollution
 
@@ -1805,18 +1812,11 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-// updateRemoteUserUID synchronizes the container user's UID/GID to match the host user
-// This is only effective on Linux where UID/GID mismatches cause permission issues
-// On macOS/Windows, Docker Desktop handles UID/GID mapping automatically
+// updateRemoteUserUID synchronizes the container user's UID/GID to match the host user.
+// This prevents permission mismatches on mounted volumes, particularly with runtimes
+// like Colima and Podman that don't provide transparent UID mapping.
+// If the container user already has the correct UID, this is a no-op.
 func updateRemoteUserUID(dockerClient *docker.Client, containerID, username string, verbose bool) error {
-	// Only run on Linux - Docker Desktop on macOS/Windows handles UID/GID mapping
-	if runtime.GOOS != "linux" {
-		if verbose {
-			fmt.Fprintf(os.Stderr, "Skipping UID/GID sync on %s (Docker Desktop handles this automatically)\n", runtime.GOOS)
-		}
-		return nil
-	}
-
 	// Get host UID/GID
 	hostUID := os.Getuid()
 	hostGID := os.Getgid()

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1841,27 +1841,27 @@ func updateRemoteUserUID(dockerClient *docker.Client, containerID, username stri
 	}
 
 	// Update user's UID
-	usermodCmd := []string{"exec", containerID, "usermod", "-u", fmt.Sprintf("%d", hostUID), username}
+	usermodCmd := []string{"exec", "-u", "root", containerID, "usermod", "-u", fmt.Sprintf("%d", hostUID), username}
 	if _, err := dockerClient.Run(usermodCmd...); err != nil {
 		return fmt.Errorf("failed to update UID: %w", err)
 	}
 
 	// Update user's GID
-	groupmodCmd := []string{"exec", containerID, "groupmod", "-g", fmt.Sprintf("%d", hostGID), username}
+	groupmodCmd := []string{"exec", "-u", "root", containerID, "groupmod", "-g", fmt.Sprintf("%d", hostGID), username}
 	if _, err := dockerClient.Run(groupmodCmd...); err != nil {
 		// Try creating a new group if groupmod fails (user might not have a group with the same name)
 		if verbose {
 			fmt.Fprintf(os.Stderr, "groupmod failed, user might not have a primary group with the same name\n")
 		}
 		// Update the user's primary GID directly
-		usermodGIDCmd := []string{"exec", containerID, "usermod", "-g", fmt.Sprintf("%d", hostGID), username}
+		usermodGIDCmd := []string{"exec", "-u", "root", containerID, "usermod", "-g", fmt.Sprintf("%d", hostGID), username}
 		if _, err := dockerClient.Run(usermodGIDCmd...); err != nil {
 			return fmt.Errorf("failed to update GID: %w", err)
 		}
 	}
 
 	// Fix ownership of user's home directory
-	chownCmd := []string{"exec", containerID, "chown", "-R", fmt.Sprintf("%d:%d", hostUID, hostGID), fmt.Sprintf("/home/%s", username)}
+	chownCmd := []string{"exec", "-u", "root", containerID, "chown", "-R", fmt.Sprintf("%d:%d", hostUID, hostGID), fmt.Sprintf("/home/%s", username)}
 	if _, err := dockerClient.Run(chownCmd...); err != nil {
 		// Not fatal - home directory might not exist or might be mounted
 		if verbose {


### PR DESCRIPTION
## Summary

- Make containers work with Colima, Podman, and other non-Docker-Desktop runtimes
- Use `$HOME` for E2E test temp dirs so they're mountable by all runtimes (Colima only shares `/Users` by default, not `/var/folders`)
- Run `usermod`/`groupmod`/`chown` as root in `updateRemoteUserUID` (non-Docker-Desktop runtimes don't implicitly run exec as root)
- Mount `~/.config/gh` on all platforms, not just Linux
- Set `GIT_CONFIG_COUNT` env vars to configure `safe.directory=*` and prevent "dubious ownership" errors
- Remove macOS gate from `updateRemoteUserUID` since Docker Desktop isn't the only macOS runtime
- Fix staticcheck QF1012 lint violation in dockerfile generator

## Test plan

- [x] `go test ./pkg/runner/ -run TestE2E_UpdateRemoteUserUID -v`
- [x] `go test ./pkg/runner/ -run TestE2E_GitSafeDirectory -v`
- [x] `go test ./pkg/runner/ -run TestE2E_GHCredsMount -v`
- [x] Full E2E suite on macOS with Colima (all pass except pre-existing Docker Compose plugin failures)
- [x] CI tests pass
- [ ] Verify E2E tests pass on macOS with Docker Desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GH CLI credentials now mount across platforms; git safe.directory is auto-configured for container sessions.
  * UID/GID synchronization now runs cross-platform to ensure correct ownership inside containers.

* **Bug Fixes**
  * Git operations in containers with mismatched ownership now work reliably.

* **Documentation**
  * Clarified GitHub CLI credential wording, simplified macOS Keychain notes, and updated macOS Docker runtime guidance.

* **Tests**
  * Added end-to-end tests for safe.directory handling and GH credential mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->